### PR TITLE
Allow spaces in key name

### DIFF
--- a/scripts/src/__tests__/admin/HeaderAccessor.unit.test.tsx
+++ b/scripts/src/__tests__/admin/HeaderAccessor.unit.test.tsx
@@ -34,13 +34,17 @@ it('regular accessors are working properly', () => {
     expect(result).toEqual("John");
 });
 
-it('accessors with spaces are working properly', () => {
-    const result = Headers.headerAccessor(formData, "name.last name.first", schema);
+it('accessors for properties with spaces in names', () => {
+    const result = Headers.headerAccessor({"First Name": "John"}, "First Name", {"properties": {"First Name": {"type": "string"}}});
+    expect(result).toEqual("John");
+});
+
+it('multi-property accessors are working properly', () => {
+    const result = Headers.headerAccessor(formData, ["name.last", "name.first"], schema);
     expect(result).toEqual("Doe John");
 });
 
-
-it('array accessors with spaces', () => {
-    const result = Headers.headerAccessor(formData, "parents.age parents.gender", schema);
+it('multi-property accessors for properties in an array', () => {
+    const result = Headers.headerAccessor(formData, ["parents.age", "parents.gender"], schema);
     expect(result).toEqual("12, 44, 73 M, F, ");
 });

--- a/scripts/src/__tests__/admin/ResponseTableView.unit.test.tsx
+++ b/scripts/src/__tests__/admin/ResponseTableView.unit.test.tsx
@@ -28,7 +28,7 @@ it('responses with default data', () => {
       },
       {
         "label": "Phone numbers",
-        "value": "home_phone parents.phone"
+        "value": ["home_phone", "parents.phone"]
       },
       {
         "label": "Parent email addresses",
@@ -36,7 +36,7 @@ it('responses with default data', () => {
       },
       {
         "label": "Home address",
-        "value": "address.line1 address.line2 address.city address.state address.zipcode"
+        "value": ["address.line1", "address.line2", "address.city", "address.state", "address.zipcode"]
       },
       {
         "label": "Child first names",
@@ -110,7 +110,7 @@ it('responses with unwind data', () => {
       },
       {
         "label": "Phone numbers",
-        "value": "home_phone parents.phone"
+        "value": ["home_phone", "parents.phone"]
       },
       {
         "label": "Parent email addresses",
@@ -118,7 +118,7 @@ it('responses with unwind data', () => {
       },
       {
         "label": "Home address",
-        "value": "address.line1 address.line2 address.city address.state address.zipcode"
+        "value": ["address.line1", "address.line2", "address.city", "address.state", "address.zipcode"]
       },
       {
         "label": "Volunteering",
@@ -145,7 +145,7 @@ it('renders response table with group assign', () => {
     "displayName": "Children Class Assign Display Name",
     "unwindBy": "children",
     "columns": [
-      { "label": "Name", "value": "children.name.first children.name.last" },
+      { "label": "Name", "value": ["children.name.first", "children.name.last"] },
       { "label": "Grade", "value": "children.grade" },
       { "label": "Class", "value": "children.class", "groupAssign": "class" }
     ]
@@ -171,7 +171,7 @@ it('renders response table with an undefined group assign', () => {
     "displayName": "Children Class Assign Display Name",
     "unwindBy": "children",
     "columns": [
-      { "label": "Name", "value": "children.name.first children.name.last" },
+      { "label": "Name", "value": ["children.name.first", "children.name.last"] },
       { "label": "Grade", "value": "children.grade" },
       { "label": "Class", "value": "children.class", "groupAssign": "class" }
     ]
@@ -192,7 +192,7 @@ it('renders response table with extra columns from the group', () => {
     "displayName": "Children Class Assign Display Name",
     "unwindBy": "children",
     "columns": [
-      { "label": "Name", "value": "children.name.first children.name.last" },
+      { "label": "Name", "value": ["children.name.first", "children.name.last"] },
       { "label": "Grade", "value": "children.grade" },
       { "label": "Class Name", "value": "children.class", "groupAssign": "class", "groupAssignDisplayPath": "displayName" },
       { "label": "Class Room", "value": "children.class", "groupAssign": "class", "groupAssignDisplayPath": "room" }
@@ -242,10 +242,10 @@ it('renders response table with groups and displaying another model', () => {
     "displayName": "Children Class Assign Display Name",
     "unwindBy": "children",
     "columns": [
-      { "label": "Name", "value": "children.name.first children.name.last" },
+      { "label": "Name", "value": ["children.name.first", "children.name.last"] },
       { "label": "Grade", "value": "children.grade" },
       { "label": "Class Name", "value": "children.class", "groupAssign": "class", "groupAssignDisplayPath": "displayName" },
-      { "label": "Teacher Name", "value": "children.class", "groupAssign": "class", "groupAssignDisplayPath": "name.first name.last", "groupAssignDisplayModel": "parents" },
+      { "label": "Teacher Name", "value": "children.class", "groupAssign": "class", "groupAssignDisplayPath": ["name.first", "name.last"], "groupAssignDisplayModel": "parents" },
       { "label": "Teacher Email", "value": "children.class", "groupAssign": "class", "groupAssignDisplayPath": "email", "groupAssignDisplayModel": "parents" }
     ]
   };

--- a/scripts/src/admin/FormEdit/FormEdit.d.ts
+++ b/scripts/src/admin/FormEdit/FormEdit.d.ts
@@ -142,8 +142,8 @@ interface IDataOptionView {
     id: string,
     columns?: ({
         label: string,
-        value: string
-    } | string)[],
+        value: string | string[]
+    } | string | string[])[],
     groupEdit?: string,
     aggregate?: {[x: string]: any}[]
 }


### PR DESCRIPTION
Fixes #4 
- Allow spaces in key name
- (**backwards incompatible change**): Require key name to have arrays rather than string with whitespace in it