### PR TITLE
Fix groupedit automatically firing onchange at load

### DIFF
--- a/scripts/src/admin/util/Headers.tsx
+++ b/scripts/src/admin/util/Headers.tsx
@@ -218,6 +218,7 @@ export module Headers {
         };
         headerObj.headerClassName = "ccmt-cff-no-click";
         headerObj.Cell = row => <Form schema={selectSchema} uiSchema={{}} formData={row.value} onChange={e => {
+            if (typeof e.formData === "undefined") return;
             let path = headerObj.id; // children.class
             if (row.original.CFF_UNWIND_BY) {
                 path = path.replace(row.original.CFF_UNWIND_BY + ".", ""); // class


### PR DESCRIPTION
Fixes a bug in which when loading groupedit ("Teachers" view for Marietta BV), it would automatically fire onChange in the form and thus send an empty edit request to the API, which returns a 500 error.