### PR TITLE
Update verbiage for form closing

### DIFF
--- a/scripts/src/form/FormPage.tsx
+++ b/scripts/src/form/FormPage.tsx
@@ -263,13 +263,12 @@ class FormPage extends React.Component<IFormPageProps, IFormPageState> {
       return (<div>
         <h1>Submissions Closed</h1>
         <p>Submissions are closed for the form: {this.state.schema.title}</p>
-        <p>Check omrun@cmsj.org ... </p>
       </div>)
     }
     if (get(this.state.formOptions, "responseModificationEnabled", true) === false && this.state.status !== STATUS_FORM_CONFIRMATION && this.state.status !== STATUS_FORM_RESPONSE_VIEW && this.state.responseId) {
       return (<div>
         <h1>Response Modifications Closed</h1>
-        <p>Response modifications are closed for the form.</p>
+        <p>Response modifications are closed for the form: {this.state.schema.title}</p>
       </div>)
     }
     let formToReturn = (


### PR DESCRIPTION
- When form submissions are closed, no longer show "omrun@cmsj.org" info.
- When form modifications are closed, show the form name to be consistent with the form submission closing verbiage.