### PR TITLE
fix: show only text for form name when it's closed, not the html

### DIFF
--- a/scripts/src/form/FormPage.tsx
+++ b/scripts/src/form/FormPage.tsx
@@ -262,13 +262,13 @@ class FormPage extends React.Component<IFormPageProps, IFormPageState> {
     if (get(this.state.formOptions, "responseSubmissionEnabled", true) === false) {
       return (<div>
         <h1>Submissions Closed</h1>
-        <p>Submissions are closed for the form: {this.state.schema.title}</p>
+        <p>Submissions are closed for the form: {htmlToText(this.state.schema.title)}</p>
       </div>)
     }
     if (get(this.state.formOptions, "responseModificationEnabled", true) === false && this.state.status !== STATUS_FORM_CONFIRMATION && this.state.status !== STATUS_FORM_RESPONSE_VIEW && this.state.responseId) {
       return (<div>
         <h1>Response Modifications Closed</h1>
-        <p>Response modifications are closed for the form: {this.state.schema.title}</p>
+        <p>Response modifications are closed for the form: {htmlToText(this.state.schema.title)}</p>
       </div>)
     }
     let formToReturn = (


### PR DESCRIPTION
Otherwise it causes issues like this one:

![image](https://user-images.githubusercontent.com/1689183/59244350-e8fb1580-8bc8-11e9-9388-a3fe4b2fb833.png)
