### PR TITLE
Autopopulate Fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1668,12 +1668,6 @@
       "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
       "dev": true
     },
-    "acorn-dynamic-import": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
-      "dev": true
-    },
     "acorn-globals": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
@@ -2028,11 +2022,12 @@
       }
     },
     "assert": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
       "dev": true,
       "requires": {
+        "object-assign": "^4.1.1",
         "util": "0.10.3"
       },
       "dependencies": {
@@ -4113,27 +4108,47 @@
       "dev": true
     },
     "cacache": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
-      "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
+      "integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.5.3",
+        "bluebird": "^3.5.5",
         "chownr": "^1.1.1",
         "figgy-pudding": "^3.5.1",
-        "glob": "^7.1.3",
+        "glob": "^7.1.4",
         "graceful-fs": "^4.1.15",
         "lru-cache": "^5.1.1",
         "mississippi": "^3.0.0",
         "mkdirp": "^0.5.1",
         "move-concurrently": "^1.0.1",
         "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.2",
+        "rimraf": "^2.6.3",
         "ssri": "^6.0.1",
         "unique-filename": "^1.1.1",
         "y18n": "^4.0.0"
       },
       "dependencies": {
+        "bluebird": {
+          "version": "3.5.5",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "lru-cache": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4372,9 +4387,9 @@
       }
     },
     "chokidar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.2.tgz",
-      "integrity": "sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+      "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
@@ -4388,7 +4403,7 @@
         "normalize-path": "^3.0.0",
         "path-is-absolute": "^1.0.0",
         "readdirp": "^2.2.1",
-        "upath": "^1.1.0"
+        "upath": "^1.1.1"
       }
     },
     "chownr": {
@@ -5838,9 +5853,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+      "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -8854,12 +8869,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
-      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -13277,9 +13286,9 @@
       "dev": true
     },
     "node-libs-browser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
-      "integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+      "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
       "dev": true,
       "requires": {
         "assert": "^1.1.1",
@@ -13292,7 +13301,7 @@
         "events": "^3.0.0",
         "https-browserify": "^1.0.0",
         "os-browserify": "^0.3.0",
-        "path-browserify": "0.0.0",
+        "path-browserify": "0.0.1",
         "process": "^0.11.10",
         "punycode": "^1.2.4",
         "querystring-es3": "^0.2.0",
@@ -13304,7 +13313,7 @@
         "tty-browserify": "0.0.0",
         "url": "^0.11.0",
         "util": "^0.11.0",
-        "vm-browserify": "0.0.4"
+        "vm-browserify": "^1.0.1"
       },
       "dependencies": {
         "buffer": {
@@ -13907,9 +13916,9 @@
       "integrity": "sha1-/bPD2EWgo8kt5CKyrZNGzginFBM="
     },
     "path-browserify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
       "dev": true
     },
     "path-dirname": {
@@ -17167,21 +17176,37 @@
       }
     },
     "terser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.0.0.tgz",
-      "integrity": "sha512-dOapGTU0hETFl1tCo4t56FN+2jffoKyER9qBGoUFyZ6y7WLoKT0bF+lAYi6B6YsILcGF3q1C2FBh8QcKSCgkgA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.2.tgz",
+      "integrity": "sha512-jvNoEQSPXJdssFwqPSgWjsOrb+ELoE+ILpHPKXC83tIxOlh2U75F1KuB2luLD/3a6/7K3Vw5pDn+hvu0C4AzSw==",
       "dev": true,
       "requires": {
-        "commander": "^2.19.0",
+        "commander": "^2.20.0",
         "source-map": "~0.6.1",
-        "source-map-support": "~0.5.10"
+        "source-map-support": "~0.5.12"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.12",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+          "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
         }
       }
     },
@@ -18387,13 +18412,10 @@
       }
     },
     "vm-browserify": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "dev": true,
-      "requires": {
-        "indexof": "0.0.1"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
+      "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.1",
@@ -18502,17 +18524,16 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.33.0.tgz",
-      "integrity": "sha512-ggWMb0B2QUuYso6FPZKUohOgfm+Z0sVFs8WwWuSH1IAvkWs428VDNmOlAxvHGTB9Dm/qOB/qtE5cRx5y01clxw==",
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.36.1.tgz",
+      "integrity": "sha512-Ej01/N9W8DVyhEpeQnbUdGvOECw0L46FxS12cCOs8gSK7bhUlrbHRnWkjiXckGlHjUrmL89kDpTRIkUk6Y+fKg==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-module-context": "1.8.5",
         "@webassemblyjs/wasm-edit": "1.8.5",
         "@webassemblyjs/wasm-parser": "1.8.5",
-        "acorn": "^6.0.5",
-        "acorn-dynamic-import": "^4.0.0",
+        "acorn": "^6.2.0",
         "ajv": "^6.1.0",
         "ajv-keywords": "^3.1.0",
         "chrome-trace-event": "^1.0.0",
@@ -18533,6 +18554,12 @@
         "webpack-sources": "^1.3.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+          "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+          "dev": true
+        },
         "schema-utils": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "typescript": "^3.5.2",
     "uglifyjs-webpack-plugin": "^1.2.3",
     "url-loader": "^1.0.1",
-    "webpack": "^4.33.0",
+    "webpack": "^4.36.1",
     "webpack-cli": "^3.3.0",
     "webpack-dev-server": "^3.7.1",
     "webpack-merge": "^4.1.2"

--- a/scripts/src/__tests__/AutoPopulateField.unit.test.tsx
+++ b/scripts/src/__tests__/AutoPopulateField.unit.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { shallow, mount, render } from "enzyme";
+import CustomForm from "../form/CustomForm";
+import { getSchemaFromResults } from "../form/form_widgets/AutoPopulateField";
+
+declare global {
+  namespace NodeJS {
+    interface Global {
+      document: Document;
+      window: Window;
+      navigator: Navigator;
+      fetch: any;
+    }
+  }
+}
+
+// afterEach(() => {
+//     if (global.fetch) {
+//         global.fetch.mockClear();
+//         delete global.fetch;
+//     }
+// });
+
+// function mockFetch(mockSuccessResponse) {
+//     const mockJsonPromise = Promise.resolve(mockSuccessResponse); // 2
+//     const mockFetchPromise = Promise.resolve({ // 3
+//         json: () => mockJsonPromise,
+//     });
+//     global.fetch = jest.fn().mockImplementation(() => mockFetchPromise);
+// }
+
+describe("getSchemaFromResults", () => {
+  it("base case", () => {
+    let results = [
+      {
+        address1: "A",
+        city: "City",
+        state: "State",
+        zip: "Zipcode",
+        name: "Center Name 1"
+      }
+    ];
+    let schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        address1: { type: "string" },
+        state: { type: "string" },
+        zip: { type: "string" }
+      }
+    };
+    let titleAccessor = "name";
+    expect(
+      getSchemaFromResults({ results, schema, titleAccessor })
+    ).toMatchSnapshot();
+  });
+});

--- a/scripts/src/__tests__/AutoPopulateField.unit.test.tsx
+++ b/scripts/src/__tests__/AutoPopulateField.unit.test.tsx
@@ -50,8 +50,33 @@ describe("getSchemaFromResults", () => {
       }
     };
     let titleAccessor = "name";
-    expect(
-      getSchemaFromResults({ results, schema, titleAccessor })
-    ).toMatchSnapshot();
+    let newSchema = getSchemaFromResults({ results, schema, titleAccessor });
+    expect(newSchema).toMatchSnapshot();
+  });
+  it("should preserve title from schema", () => {
+    let results = [
+      {
+        address1: "A",
+        city: "City",
+        state: "State",
+        zip: "Zipcode",
+        name: "Center Name 1"
+      }
+    ];
+    let schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        address1: { type: "string" },
+        state: { type: "string" },
+        zip: { title: "Zip / Pincode", type: "string" }
+      }
+    };
+    let titleAccessor = "name";
+    let newSchema = getSchemaFromResults({ results, schema, titleAccessor });
+    expect(newSchema).toMatchSnapshot();
+    expect(newSchema.dependencies.name.oneOf[0].properties.zip.title).toEqual(
+      "Zip / Pincode"
+    );
   });
 });

--- a/scripts/src/__tests__/__snapshots__/AutoPopulateField.unit.test.tsx.snap
+++ b/scripts/src/__tests__/__snapshots__/AutoPopulateField.unit.test.tsx.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getSchemaFromResults base case 1`] = `
+Object {
+  "dependencies": Object {
+    "name": Object {
+      "oneOf": Array [
+        Object {
+          "properties": Object {
+            "address1": Object {
+              "default": "A",
+              "enum": Array [
+                "A",
+              ],
+              "readOnly": true,
+              "type": "string",
+            },
+            "name": Object {
+              "const": "Center Name 1",
+            },
+            "state": Object {
+              "default": "State",
+              "enum": Array [
+                "State",
+              ],
+              "readOnly": true,
+              "type": "string",
+            },
+            "zip": Object {
+              "default": "Zipcode",
+              "enum": Array [
+                "Zipcode",
+              ],
+              "readOnly": true,
+              "type": "string",
+            },
+          },
+        },
+      ],
+    },
+  },
+  "properties": Object {
+    "name": Object {
+      "enum": Array [
+        "Center Name 1",
+      ],
+      "type": "string",
+    },
+  },
+  "type": "object",
+}
+`;

--- a/scripts/src/__tests__/__snapshots__/AutoPopulateField.unit.test.tsx.snap
+++ b/scripts/src/__tests__/__snapshots__/AutoPopulateField.unit.test.tsx.snap
@@ -50,3 +50,55 @@ Object {
   "type": "object",
 }
 `;
+
+exports[`getSchemaFromResults should preserve title from schema 1`] = `
+Object {
+  "dependencies": Object {
+    "name": Object {
+      "oneOf": Array [
+        Object {
+          "properties": Object {
+            "address1": Object {
+              "default": "A",
+              "enum": Array [
+                "A",
+              ],
+              "readOnly": true,
+              "type": "string",
+            },
+            "name": Object {
+              "const": "Center Name 1",
+            },
+            "state": Object {
+              "default": "State",
+              "enum": Array [
+                "State",
+              ],
+              "readOnly": true,
+              "type": "string",
+            },
+            "zip": Object {
+              "default": "Zipcode",
+              "enum": Array [
+                "Zipcode",
+              ],
+              "readOnly": true,
+              "title": "Zip / Pincode",
+              "type": "string",
+            },
+          },
+        },
+      ],
+    },
+  },
+  "properties": Object {
+    "name": Object {
+      "enum": Array [
+        "Center Name 1",
+      ],
+      "type": "string",
+    },
+  },
+  "type": "object",
+}
+`;

--- a/scripts/src/form/form_widgets/AutoPopulateField.tsx
+++ b/scripts/src/form/form_widgets/AutoPopulateField.tsx
@@ -12,6 +12,7 @@ export function getSchemaFromResults({ results, schema, titleAccessor }) {
       // Always true for now.
       for (let key in schema.properties) {
         option["properties"][key] = {
+          ...schema.properties[key],
           type: typeof result[key],
           default: result[key],
           enum: [result[key]],

--- a/scripts/src/form/form_widgets/AutoPopulateField.tsx
+++ b/scripts/src/form/form_widgets/AutoPopulateField.tsx
@@ -4,6 +4,54 @@ import Loading from "../../common/Loading/Loading";
 import CustomForm from "../CustomForm";
 import "./AutoPopulateField.scss";
 
+export function getSchemaFromResults({ results, schema, titleAccessor }) {
+  let options: any = [];
+  for (let result of results) {
+    let option = { properties: {} };
+    if (schema.type === "object") {
+      // Always true for now.
+      for (let key in schema.properties) {
+        option["properties"][key] = {
+          type: typeof result[key],
+          default: result[key],
+          enum: [result[key]],
+          readOnly: true
+        };
+        if (titleAccessor) {
+          // Always true for now.
+          option["properties"][titleAccessor] = {
+            const: get(result, titleAccessor)
+          };
+        }
+      }
+    }
+    // TODO: work with other types.
+    else {
+      option = result;
+    }
+    options.push(option);
+  }
+  // Sort options alphabetically.
+  options = sortBy(
+    options,
+    option => option["properties"][titleAccessor].const
+  );
+  let newSchema = {
+    ...schema,
+    properties: {
+      [titleAccessor]: {
+        ...schema.properties[titleAccessor],
+        enum: options.map(option => option["properties"][titleAccessor].const)
+      }
+    },
+    dependencies: {
+      [titleAccessor]: {
+        oneOf: options
+      }
+    }
+  };
+  return newSchema;
+}
 class AutoPopulateField extends React.Component<any, any> {
   constructor(props: any) {
     super(props);
@@ -27,56 +75,11 @@ class AutoPopulateField extends React.Component<any, any> {
         results = await fetch(endpoint).then(e => e.json());
         sessionStorage.setItem(endpoint, JSON.stringify(results));
       }
-      let options: any = [];
-      // options.push(
-      //     {"title": this.props.uiSchema["ui:placeholder"] || `Select ${this.props.name}`, "type": "object", "properties": {"a": {"type": "string"}}, "required": ["a"] }
-      // );
-      for (let result of results) {
-        let option = { properties: {} };
-        if (this.props.schema.type === "object") {
-          // Always true for now.
-          for (let key in this.props.schema.properties) {
-            option["properties"][key] = {
-              type: typeof result[key],
-              default: result[key],
-              enum: [result[key]],
-              readOnly: true
-            };
-            if (titleAccessor) {
-              // Always true for now.
-              option["properties"][titleAccessor] = {
-                const: get(result, titleAccessor)
-              };
-            }
-          }
-        }
-        // TODO: work with other types.
-        else {
-          option = result;
-        }
-        options.push(option);
-      }
-      // Sort options alphabetically.
-      options = sortBy(
-        options,
-        option => option["properties"][titleAccessor].const
-      );
-      let newSchema = {
-        ...this.props.schema,
-        properties: {
-          [titleAccessor]: {
-            ...this.props.schema.properties[titleAccessor],
-            enum: options.map(
-              option => option["properties"][titleAccessor].const
-            )
-          }
-        },
-        dependencies: {
-          [titleAccessor]: {
-            oneOf: options
-          }
-        }
-      };
+      let newSchema = getSchemaFromResults({
+        results,
+        schema: this.props.schema,
+        titleAccessor
+      });
       this.setState({
         loading: false,
         newSchema


### PR DESCRIPTION
Fixes #126 

Specifically, fixes the case in which there are additional elements in the schema (such as `title`, etc.) that need to be carried over to the Autopopulate-generated schema.