### PR TITLE
Speed up form list clicking / right clicking

### DIFF
--- a/scripts/src/admin/FormList/FormList.tsx
+++ b/scripts/src/admin/FormList/FormList.tsx
@@ -1,17 +1,13 @@
-import * as React from "react";
+import React from "react";
 import API from "@aws-amplify/api";
-import { BrowserRouter as Router, Route, NavLink } from "react-router-dom";
 import { isArray } from "lodash";
 import "./FormList.scss";
 import FormNew from "../FormNew/FormNew";
 import { connect } from "react-redux";
-import dataLoadingView from "../util/DataLoadingView";
 import { IFormListProps, IFormListState } from "./FormList.d";
 import { loadFormList, createForm } from "../../store/admin/actions";
-import { ContextMenu, MenuItem, ContextMenuTrigger } from "react-contextmenu";
-import history from "../../history";
 import Loading from "../../common/Loading/Loading";
-import FormPageMenu from "../FormPageMenu";
+import FormListItem from "./FormListItem";
 
 const mapStateToProps = state => ({
   ...state.auth,
@@ -22,19 +18,6 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   loadFormList: () => dispatch(loadFormList()),
   createForm: e => dispatch(createForm(e))
 });
-
-function hashCode(str) {
-  // java String#hashCode
-  var hash = 0;
-  for (var i = 0; i < str.length; i++) {
-    hash = str.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  return hash;
-}
-
-function intToRGB(number) {
-  return "#" + (number >>> 0).toString(16).slice(-6);
-}
 
 export function hasPermission(cff_permissions, permissionNames, userId) {
   if (!isArray(permissionNames)) {
@@ -107,77 +90,14 @@ class FormList extends React.Component<IFormListProps, IFormListState> {
         {formList && formList.length == 0 && "No forms found."}
         {formList &&
           formList.map(form => (
-            <React.Fragment key={form["_id"]["$oid"]}>
-              <ContextMenuTrigger id={form["_id"]["$oid"]}>
-                <div
-                  className="row"
-                  style={{
-                    padding: 10,
-                    whiteSpace: "nowrap",
-                    borderBottom: "1px solid #aaa",
-                    backgroundColor:
-                      form["_id"]["$oid"] === this.state.highlightedForm
-                        ? "lightblue"
-                        : "white"
-                  }}
-                  onClick={() => this.highlightForm(form, form["_id"]["$oid"])}
-                  key={form["_id"]["$oid"]}
-                  onContextMenu={() =>
-                    this.highlightForm(form, form["_id"]["$oid"])
-                  }
-                >
-                  <div className="col-sm">{form["name"]}</div>
-                  <div className="col-sm d-none">
-                    Modified{" "}
-                    {new Date(
-                      form["date_modified"]["$date"]
-                    ).toLocaleDateString()}
-                  </div>
-                  <div className="col-sm d-none">
-                    Created{" "}
-                    {new Date(
-                      form["date_created"]["$date"]
-                    ).toLocaleDateString()}
-                  </div>
-                  <div className="col-sm">
-                    {form["tags"] &&
-                      form["tags"].map(tag => (
-                        <div
-                          className="badge badge-secondary"
-                          style={{ backgroundColor: intToRGB(hashCode(tag)) }}
-                        >
-                          {tag}
-                        </div>
-                      ))}
-                  </div>
-                </div>
-              </ContextMenuTrigger>
-              {this.state.highlightedForm === form._id.$oid && (
-                <div className="d-block d-sm-none">
-                  <FormPageMenu
-                    formId={form._id.$oid}
-                    ItemComponent={props => (
-                      <button className="btn btn-sm btn-outline-primary">
-                        {props.children}
-                      </button>
-                    )}
-                    onDelete={e => this.delete(form._id.$oid)}
-                    onDuplicate={e => this.props.createForm(form._id.$oid)}
-                  />
-                </div>
-              )}
-              <ContextMenu
-                className="d-none d-sm-block"
-                id={form["_id"]["$oid"]}
-              >
-                <FormPageMenu
-                  formId={form._id.$oid}
-                  ItemComponent={props => <MenuItem>{props.children}</MenuItem>}
-                  onDelete={e => this.delete(form._id.$oid)}
-                  onDuplicate={e => this.props.createForm(form._id.$oid)}
-                />
-              </ContextMenu>
-            </React.Fragment>
+            <FormListItem
+              key={form["_id"]["$oid"]}
+              form={form}
+              delete={e => this.delete(e)}
+              highlightForm={(e, f) => this.highlightForm(e, f)}
+              createForm={e => this.props.createForm(e)}
+              highlightedForm={this.state.highlightedForm}
+            />
           ))}
       </div>
     );

--- a/scripts/src/admin/FormList/FormList.tsx
+++ b/scripts/src/admin/FormList/FormList.tsx
@@ -91,12 +91,12 @@ class FormList extends React.Component<IFormListProps, IFormListState> {
         {formList &&
           formList.map(form => (
             <FormListItem
-              key={form["_id"]["$oid"]}
+              key={form._id.$oid}
               form={form}
-              delete={e => this.delete(e)}
-              highlightForm={(e, f) => this.highlightForm(e, f)}
-              createForm={e => this.props.createForm(e)}
-              highlightedForm={this.state.highlightedForm}
+              delete={e => this.delete(form._id.$oid)}
+              highlightForm={() => this.highlightForm(form, form._id.$oid)}
+              createForm={() => this.props.createForm(form._id.$oid)}
+              highlighted={this.state.highlightedForm === form._id.$oid}
             />
           ))}
       </div>

--- a/scripts/src/admin/FormList/FormListItem.tsx
+++ b/scripts/src/admin/FormList/FormListItem.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { ContextMenu, MenuItem, ContextMenuTrigger } from "react-contextmenu";
+import FormPageMenu from "../FormPageMenu";
+
+function hashCode(str) {
+  // java String#hashCode
+  var hash = 0;
+  for (var i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return hash;
+}
+
+function intToRGB(number) {
+  return "#" + (number >>> 0).toString(16).slice(-6);
+}
+
+export default class extends React.Component<
+  {
+    form: any;
+    highlightForm: any;
+    highlightedForm: string;
+    delete: any;
+    createForm: any;
+  },
+  {}
+> {
+  shouldComponentUpdate(prevProps) {
+    // Only update when highlight state is changed -- for efficiency.
+    return (
+      (this.props.form["_id"]["$oid"] === this.props.highlightedForm) !==
+      (prevProps.form["_id"]["$oid"] === prevProps.highlightedForm)
+    );
+  }
+  render() {
+    const {
+      form,
+      highlightForm,
+      highlightedForm,
+      delete: delete_,
+      createForm
+    } = this.props;
+    return (
+      <>
+        <ContextMenuTrigger id={form["_id"]["$oid"]}>
+          <div
+            className="row"
+            style={{
+              padding: 10,
+              whiteSpace: "nowrap",
+              borderBottom: "1px solid #aaa",
+              backgroundColor:
+                form["_id"]["$oid"] === highlightedForm ? "lightblue" : "white"
+            }}
+            onClick={() => highlightForm(form, form["_id"]["$oid"])}
+            key={form["_id"]["$oid"]}
+            onContextMenu={() => highlightForm(form, form["_id"]["$oid"])}
+          >
+            <div className="col-sm">{form["name"]}</div>
+            <div className="col-sm d-none">
+              Modified{" "}
+              {new Date(form["date_modified"]["$date"]).toLocaleDateString()}
+            </div>
+            <div className="col-sm d-none">
+              Created{" "}
+              {new Date(form["date_created"]["$date"]).toLocaleDateString()}
+            </div>
+            <div className="col-sm">
+              {form["tags"] &&
+                form["tags"].map(tag => (
+                  <div
+                    className="badge badge-secondary"
+                    style={{ backgroundColor: intToRGB(hashCode(tag)) }}
+                  >
+                    {tag}
+                  </div>
+                ))}
+            </div>
+          </div>
+        </ContextMenuTrigger>
+        {highlightedForm === form._id.$oid && (
+          <div className="d-block d-sm-none">
+            <FormPageMenu
+              formId={form._id.$oid}
+              ItemComponent={props => (
+                <button className="btn btn-sm btn-outline-primary">
+                  {props.children}
+                </button>
+              )}
+              onDelete={e => delete_(form._id.$oid)}
+              onDuplicate={e => createForm(form._id.$oid)}
+            />
+          </div>
+        )}
+        <ContextMenu className="d-none d-sm-block" id={form["_id"]["$oid"]}>
+          <FormPageMenu
+            formId={form._id.$oid}
+            ItemComponent={props => <MenuItem>{props.children}</MenuItem>}
+            onDelete={e => delete_(form._id.$oid)}
+            onDuplicate={e => createForm(form._id.$oid)}
+          />
+        </ContextMenu>
+      </>
+    );
+  }
+}

--- a/scripts/src/admin/FormList/FormListItem.tsx
+++ b/scripts/src/admin/FormList/FormListItem.tsx
@@ -19,7 +19,7 @@ export default class extends React.Component<
   {
     form: any;
     highlightForm: any;
-    highlightedForm: string;
+    highlighted: boolean;
     delete: any;
     createForm: any;
   },
@@ -27,34 +27,30 @@ export default class extends React.Component<
 > {
   shouldComponentUpdate(prevProps) {
     // Only update when highlight state is changed -- for efficiency.
-    return (
-      (this.props.form["_id"]["$oid"] === this.props.highlightedForm) !==
-      (prevProps.form["_id"]["$oid"] === prevProps.highlightedForm)
-    );
+    return this.props.highlighted !== prevProps.highlighted;
   }
   render() {
     const {
       form,
       highlightForm,
-      highlightedForm,
+      highlighted,
       delete: delete_,
       createForm
     } = this.props;
     return (
       <>
-        <ContextMenuTrigger id={form["_id"]["$oid"]}>
+        <ContextMenuTrigger id={form._id.$oid}>
           <div
             className="row"
             style={{
               padding: 10,
               whiteSpace: "nowrap",
               borderBottom: "1px solid #aaa",
-              backgroundColor:
-                form["_id"]["$oid"] === highlightedForm ? "lightblue" : "white"
+              backgroundColor: highlighted ? "lightblue" : "white"
             }}
-            onClick={() => highlightForm(form, form["_id"]["$oid"])}
+            onClick={() => highlightForm()}
             key={form["_id"]["$oid"]}
-            onContextMenu={() => highlightForm(form, form["_id"]["$oid"])}
+            onContextMenu={() => highlightForm()}
           >
             <div className="col-sm">{form["name"]}</div>
             <div className="col-sm d-none">
@@ -78,7 +74,7 @@ export default class extends React.Component<
             </div>
           </div>
         </ContextMenuTrigger>
-        {highlightedForm === form._id.$oid && (
+        {highlighted && (
           <div className="d-block d-sm-none">
             <FormPageMenu
               formId={form._id.$oid}
@@ -87,8 +83,8 @@ export default class extends React.Component<
                   {props.children}
                 </button>
               )}
-              onDelete={e => delete_(form._id.$oid)}
-              onDuplicate={e => createForm(form._id.$oid)}
+              onDelete={e => delete_()}
+              onDuplicate={e => createForm()}
             />
           </div>
         )}
@@ -96,8 +92,8 @@ export default class extends React.Component<
           <FormPageMenu
             formId={form._id.$oid}
             ItemComponent={props => <MenuItem>{props.children}</MenuItem>}
-            onDelete={e => delete_(form._id.$oid)}
-            onDuplicate={e => createForm(form._id.$oid)}
+            onDelete={e => delete_()}
+            onDuplicate={e => createForm()}
           />
         </ContextMenu>
       </>


### PR DESCRIPTION
Speed up left / right clicking of form list.

Previously, left / right clicking on a form in the form list would induce a momentary delay because it would cause _all_ the components to re-render. This change makes sure that only that single row re-renders.