### PR TITLE
Preventing refreshing  the page after a form is  deleted.

### DIFF
--- a/scripts/src/admin/FormList/FormList.tsx
+++ b/scripts/src/admin/FormList/FormList.tsx
@@ -73,7 +73,7 @@ class FormList extends React.Component<IFormListProps, IFormListState> {
       API.del("CFF", `/forms/${formId}`, {})
         .then(e => {
           alert("Form deleted!");
-          window.location.reload();
+          this.props.loadFormList();
         })
         .catch(e => {
           alert(`Delete failed: ${e}`);


### PR DESCRIPTION
Instead of doing an explicit reload of the page, now we are only reloading the list so the entire page refresh is not as desired.