### PR TITLE
Show "total" column in payment table

### DIFF
--- a/docs/payment/payment-table.md
+++ b/docs/payment/payment-table.md
@@ -1,0 +1,25 @@
+When showing a payment table (such as in the confirmation email), you have the following object to work with:
+
+```
+{
+    "currency": "USD",
+    "total": 4,
+    "items": [
+        {
+            "name": "Name",
+            "description": "Name",
+            "amount": 2,
+            "quantity": 2,
+            "total": 4
+        }
+    ]
+}
+```
+
+Note that the `total` key in each element in `items` represents a single subtotal (`amount * quantity`), while `paymentInfo.total` represents the total amount owed, adding up all paymentInfo items.
+
+## Notes for installment items
+
+Note that the totals for installment items (with `installment: true`) are not summed up when calculating `paymentInfo.total`.
+
+When `recurrenceTimes` is specified for an item, then the `total` calculated for that item is equal to `amount * quantity * recurrenceTimes`. This applies only to installment items.

--- a/docs/payment/payment-table.md
+++ b/docs/payment/payment-table.md
@@ -22,4 +22,4 @@ Note that the `total` key in each element in `items` represents a single subtota
 
 Note that the totals for installment items (with `installment: true`) are not summed up when calculating `paymentInfo.total`.
 
-When `recurrenceTimes` is specified for an item, then the `total` calculated for that item is equal to `amount * quantity * recurrenceTimes`. This applies only to installment items.
+When `recurrenceTimes` is specified for an item, then the `total` calculated for that item is equal to `amount * quantity * recurrenceTimes`. This applies only to installment items. However, it might make most sense not to show `quantity` or `total` for installment payments.

--- a/lambda/chalicelib/routes/formResponseNew.py
+++ b/lambda/chalicelib/routes/formResponseNew.py
@@ -62,7 +62,8 @@ def form_response_new(formId):
     def calc_item_total_to_paymentInfo(paymentInfoItem, paymentInfo):
         paymentInfoItem['amount'] = calculate_price(paymentInfoItem.get('amount', '0'), response_data)
         paymentInfoItem['quantity'] = calculate_price(paymentInfoItem.get('quantity', '0'), response_data)
-        paymentInfo['total'] += paymentInfoItem['amount'] * paymentInfoItem['quantity']
+        paymentInfoItem['total'] = paymentInfoItem['amount'] * paymentInfoItem['quantity']
+        paymentInfo['total'] += paymentInfoItem['total']
         if "couponCode" in paymentInfoItem and paymentInfoItem["amount"] * paymentInfoItem["quantity"] != 0:
             slots_maximum = calculate_price(paymentInfoItem.get("couponCodeMaximum", "-1"), response_data)
             if slots_maximum != -1:
@@ -107,7 +108,8 @@ def form_response_new(formId):
     for paymentInfoItem in paymentInfoItemsInstallment:
         paymentInfoItem['amount'] = calculate_price(paymentInfoItem.get('amount', '0'), response_data)
         paymentInfoItem['quantity'] = calculate_price(paymentInfoItem.get('quantity', '0'), response_data)
-
+        if paymentInfoItem['recurrenceTimes']:
+            paymentInfoItem['total'] = paymentInfoItem['amount'] * paymentInfoItem['quantity'] * int(paymentInfoItem['recurrenceTimes'])
     response_data.pop("total", None)
 
     paymentInfo['items'] = [item for item in paymentInfo['items'] if item['quantity'] * item['amount'] != 0]

--- a/lambda/tests/integration/constants.py
+++ b/lambda/tests/integration/constants.py
@@ -194,22 +194,16 @@ EXPECTED_RES_VALUE = json.loads("""{
 FORM_DATA_ONE = {"modifyLink": "http://omrun.cmsj.org/training-thankyou/", "data": {"acceptTerms": True, "contact_name": {"last": "test", "first": "test"}, "address": {"zipcode": "test", "state": "test", "city": "test", "line2": "test",
                                                                                                                                                                         "line1": "test"}, "email": "success@simulator.amazonses.com", "participants": [{"name": {"last": "test", "first": "test"}, "gender": "M", "race": "5K", "age": 16}]}
                  }
-FORM_SUBMIT_RESP_ONE = {'paid': False, 'success': True, 'email_sent': False, 'action': 'insert', 'paymentInfo': {'manualEntry': {'enabled': True, 'inputPath': 'manualEntry'}, 'total': 25.0, 'currency': 'USD', 'redirectUrl': 'http://omrun.cmsj.org/training-thankyou/', 'items': [{'name': '2018 CMSJ OM Run',
-                                                                                                                                                                                                    'description': 'Registration for Training Only', 'amount': 25.0, 'quantity': 1.0}]}}
+
 FORM_DATA_TWO = {"modifyLink": "http://omrun.cmsj.org/training-thankyou/", "data": {"acceptTerms": True, "contact_name": {"last": "test", "first": "test"}, "address": {"zipcode": "test", "state": "test", "city": "test", "line2": "test",
                                                                                                                                                                         "line1": "test"}, "email": "success@simulator.amazonses.com", "participants": [{"name": {"last": "test", "first": "test"}, "gender": "M", "race": "5K", "age": 16},
                                                                                                                                                                                                                                              {"name": {"last": "test2", "first": "test2"}, "gender": "M", "race": "5K", "age": 16}]}
                  }
-FORM_SUBMIT_RESP_TWO = {'paid': False, 'success': True, 'email_sent': True, 'action': 'insert', 'paymentInfo': {'total': 50.0, 'currency': 'USD', 'redirectUrl': 'http://omrun.cmsj.org/training-thankyou/', 'items': [{'name': '2018 CMSJ OM Run',
-                                                                                                                                                                                                    'description': 'Registration for Training Only', 'amount': 25.0, 'quantity': 2.0}]}}
-
 FORM_DATA_TWO_5K_10K = {"modifyLink": "http://omrun.cmsj.org/training-thankyou/", "data": {"acceptTerms": True, "contact_name": {"last": "test", "first": "test"}, "address": {"zipcode": "test", "state": "test", "city": "test", "line2": "test",
                                                                                                                                                                                "line1": "test"}, "email": "success@simulator.amazonses.com", "participants": [{"name": {"last": "test", "first": "test"}, "gender": "M", "race": "5K", "age": 16},
                                                                                                                                                                                                                                                     {"name": {"last": "test2", "first": "test2"}, "gender": "M", "race": "10K", "age": 16}]}
                         }
 paymentMethods = {'paypal_classic': {'address1': 'test', 'address2': 'test', 'business': 'aramaswamis-facilitator@gmail.com', 'city': 'test', 'cmd': '_cart', 'email': 'success@simulator.amazonses.com', 'first_name': 'test', 'image_url': 'http://omrun.cmsj.org/wp-content/uploads/2017/01/cropped-Om-run-512px.png', 'item_name': 'Ashwin', 'item_number': 'Registration for ' 'Training Only', 'last_name': 'test', 'sandbox': True, 'state': 'test', 'zip': '.'}, 'paypal_old_not_used': {'client': {'sandbox': 'AQnuMqn24Q8xTChC8uSgCOnmDjeMXZ1O7ZNS0uCHIsOmcoHqA6g2acYhTa_Qv-euJJ8UVFh4zmhJAWQR'}, 'env': 'sandbox'}}
-FORM_SUBMIT_RESP_ONE["paymentMethods"] = paymentMethods
-FORM_SUBMIT_RESP_TWO["paymentMethods"] = paymentMethods
 
 
 SCHEMA_ID = "5e258c2c-9b85-40ad-b764-979fc9df1740"

--- a/scripts/src/__tests__/Payment.unit.test.tsx
+++ b/scripts/src/__tests__/Payment.unit.test.tsx
@@ -190,18 +190,7 @@ describe("calculatePaymentInfo()", () => {
       ]
     };
     let formData = {};
-    let expectedPaymentInfo = {
-      total: 4,
-      items: [
-        {
-          amount: 2,
-          quantity: 2
-        }
-      ]
-    };
-    expect(calculatePaymentInfo(paymentInfo, formData)).toEqual(
-      expectedPaymentInfo
-    );
+    expect(calculatePaymentInfo(paymentInfo, formData)).toMatchSnapshot();
   });
   it("calculates total items in paymentInfo last", () => {
     let paymentInfo = {
@@ -217,22 +206,7 @@ describe("calculatePaymentInfo()", () => {
       ]
     };
     let formData = {};
-    let expectedPaymentInfo = {
-      total: 3.6,
-      items: [
-        {
-          amount: 2,
-          quantity: 2
-        },
-        {
-          amount: -0.4,
-          quantity: 1
-        }
-      ]
-    };
-    expect(calculatePaymentInfo(paymentInfo, formData)).toEqual(
-      expectedPaymentInfo
-    );
+    expect(calculatePaymentInfo(paymentInfo, formData)).toMatchSnapshot();
   });
   it("doesn't include installments in total calculation", () => {
     let paymentInfo = {
@@ -251,25 +225,7 @@ describe("calculatePaymentInfo()", () => {
       ]
     };
     let formData = {};
-    let expectedPaymentInfo = {
-      total: 4,
-      items: [
-        {
-          amount: 2,
-          quantity: 2
-        },
-        {
-          amount: 2,
-          quantity: 1,
-          recurrenceDuration: "1M",
-          recurrenceTimes: 2,
-          installment: true
-        }
-      ]
-    };
-    expect(calculatePaymentInfo(paymentInfo, formData)).toEqual(
-      expectedPaymentInfo
-    );
+    expect(calculatePaymentInfo(paymentInfo, formData)).toMatchSnapshot();
   });
   it("calculates installments from multiple totals", () => {
     let paymentInfo = {
@@ -296,32 +252,6 @@ describe("calculatePaymentInfo()", () => {
       ]
     };
     let formData = {};
-    let expectedPaymentInfo = {
-      total: 2,
-      items: [
-        {
-          amount: 2,
-          quantity: 2
-        },
-        {
-          amount: -1,
-          quantity: 1
-        },
-        {
-          amount: -1,
-          quantity: 1
-        },
-        {
-          amount: 1,
-          quantity: 1,
-          recurrenceDuration: "1M",
-          recurrenceTimes: 2,
-          installment: true
-        }
-      ]
-    };
-    expect(calculatePaymentInfo(paymentInfo, formData)).toEqual(
-      expectedPaymentInfo
-    );
+    expect(calculatePaymentInfo(paymentInfo, formData)).toMatchSnapshot();
   });
 });

--- a/scripts/src/__tests__/Payment.unit.test.tsx
+++ b/scripts/src/__tests__/Payment.unit.test.tsx
@@ -15,7 +15,8 @@ it("renders payment table on new response", () => {
             name: "One",
             description: "One",
             amount: 12,
-            quantity: 1
+            quantity: 1,
+            total: 12
           }
         ]
       }}
@@ -51,7 +52,8 @@ it("renders payment table with amount received", () => {
             name: "One",
             description: "One",
             amount: 12,
-            quantity: 1
+            quantity: 1,
+            total: 12
           }
         ]
       }}
@@ -88,6 +90,7 @@ it("renders recurring payment table with times", () => {
             description: "One",
             amount: 12,
             quantity: 1,
+            total: 12,
             recurrenceDuration: "1M"
           }
         ]
@@ -118,15 +121,63 @@ it("renders recurring payment table with end", () => {
       onPaymentStarted={e => e}
       paymentInfo={{
         currency: "USD",
-        total: 12,
+        total: 120,
         items: [
           {
             name: "One",
             description: "One",
             amount: 12,
             quantity: 1,
+            total: 120,
             recurrenceDuration: "1M",
             recurrenceTimes: "10"
+          }
+        ]
+      }}
+      paymentInfo_owed={{
+        currency: "USD",
+        total: 0
+      }}
+      paymentInfo_received={{
+        currency: "USD",
+        total: 0
+      }}
+      paymentMethods={[]}
+      onPaymentComplete={e => e}
+      onPaymentError={e => e}
+      responseId={"responseId"}
+      formId={"formId"}
+      formData={{}}
+    />
+  );
+  expect(wrapper).toMatchSnapshot();
+  expect(wrapper.text()).not.toContain("Amount already paid");
+});
+
+it("renders installment payment table", () => {
+  const wrapper = render(
+    <Payment
+      onPaymentStarted={e => e}
+      paymentInfo={{
+        currency: "USD",
+        total: 120,
+        items: [
+          {
+            name: "One",
+            description: "One",
+            amount: 120,
+            quantity: 1,
+            total: 120
+          },
+          {
+            name: "Installment",
+            description: "Installment",
+            amount: 12,
+            quantity: 1,
+            total: 120,
+            recurrenceDuration: "1M",
+            recurrenceTimes: "10",
+            installment: true
           }
         ]
       }}

--- a/scripts/src/__tests__/__snapshots__/Payment.unit.test.tsx.snap
+++ b/scripts/src/__tests__/__snapshots__/Payment.unit.test.tsx.snap
@@ -840,7 +840,7 @@ exports[`renders recurring payment table with end 1`] = `
                     role="gridcell"
                     style="text-align:right;flex:100 0 auto;width:100px"
                   >
-                    1
+                     every month for 10 times
                   </div>
                   <div
                     class="rt-td"
@@ -1019,7 +1019,7 @@ exports[`renders recurring payment table with times 1`] = `
                     role="gridcell"
                     style="text-align:right;flex:100 0 auto;width:100px"
                   >
-                    1
+                     every month
                   </div>
                   <div
                     class="rt-td"

--- a/scripts/src/__tests__/__snapshots__/Payment.unit.test.tsx.snap
+++ b/scripts/src/__tests__/__snapshots__/Payment.unit.test.tsx.snap
@@ -6,14 +6,17 @@ Object {
     Object {
       "amount": 2,
       "quantity": 2,
+      "total": 4,
     },
     Object {
       "amount": -1,
       "quantity": 1,
+      "total": -1,
     },
     Object {
       "amount": -1,
       "quantity": 1,
+      "total": -1,
     },
     Object {
       "amount": 1,
@@ -21,6 +24,7 @@ Object {
       "quantity": 1,
       "recurrenceDuration": "1M",
       "recurrenceTimes": 2,
+      "total": 2,
     },
   ],
   "total": 2,
@@ -33,6 +37,7 @@ Object {
     Object {
       "amount": 2,
       "quantity": 2,
+      "total": 4,
     },
   ],
   "total": 4,
@@ -45,10 +50,12 @@ Object {
     Object {
       "amount": 2,
       "quantity": 2,
+      "total": 4,
     },
     Object {
       "amount": -0.4,
       "quantity": 1,
+      "total": -0.4,
     },
   ],
   "total": 3.6,
@@ -61,6 +68,7 @@ Object {
     Object {
       "amount": 2,
       "quantity": 2,
+      "total": 4,
     },
     Object {
       "amount": 2,
@@ -68,6 +76,7 @@ Object {
       "quantity": 1,
       "recurrenceDuration": "1M",
       "recurrenceTimes": 2,
+      "total": 4,
     },
   ],
   "total": 4,
@@ -113,7 +122,7 @@ exports[`renders payment table on new response 1`] = `
           >
             <div
               class="rt-thead -header"
-              style="min-width:400px"
+              style="min-width:500px"
             >
               <div
                 class="rt-tr"
@@ -179,11 +188,26 @@ exports[`renders payment table on new response 1`] = `
                     class="rt-resizer"
                   />
                 </div>
+                <div
+                  class="rt-th rt-resizable-header -cursor-pointer"
+                  role="columnheader"
+                  style="flex:100 0 auto;width:100px;max-width:100px"
+                  tabindex="-1"
+                >
+                  <div
+                    class="rt-resizable-header-content"
+                  >
+                    Total
+                  </div>
+                  <div
+                    class="rt-resizer"
+                  />
+                </div>
               </div>
             </div>
             <div
               class="rt-tbody"
-              style="min-width:400px"
+              style="min-width:500px"
             >
               <div
                 class="rt-tr-group"
@@ -221,6 +245,11 @@ exports[`renders payment table on new response 1`] = `
                   >
                     1
                   </div>
+                  <div
+                    class="rt-td"
+                    role="gridcell"
+                    style="flex:100 0 auto;width:100px;max-width:100px"
+                  />
                 </div>
               </div>
             </div>
@@ -270,7 +299,7 @@ exports[`renders payment table with amount received 1`] = `
           >
             <div
               class="rt-thead -header"
-              style="min-width:400px"
+              style="min-width:500px"
             >
               <div
                 class="rt-tr"
@@ -336,11 +365,26 @@ exports[`renders payment table with amount received 1`] = `
                     class="rt-resizer"
                   />
                 </div>
+                <div
+                  class="rt-th rt-resizable-header -cursor-pointer"
+                  role="columnheader"
+                  style="flex:100 0 auto;width:100px;max-width:100px"
+                  tabindex="-1"
+                >
+                  <div
+                    class="rt-resizable-header-content"
+                  >
+                    Total
+                  </div>
+                  <div
+                    class="rt-resizer"
+                  />
+                </div>
               </div>
             </div>
             <div
               class="rt-tbody"
-              style="min-width:400px"
+              style="min-width:500px"
             >
               <div
                 class="rt-tr-group"
@@ -378,6 +422,11 @@ exports[`renders payment table with amount received 1`] = `
                   >
                     1
                   </div>
+                  <div
+                    class="rt-td"
+                    role="gridcell"
+                    style="flex:100 0 auto;width:100px;max-width:100px"
+                  />
                 </div>
               </div>
             </div>
@@ -444,7 +493,7 @@ exports[`renders recurring payment table with end 1`] = `
           >
             <div
               class="rt-thead -header"
-              style="min-width:400px"
+              style="min-width:500px"
             >
               <div
                 class="rt-tr"
@@ -510,11 +559,26 @@ exports[`renders recurring payment table with end 1`] = `
                     class="rt-resizer"
                   />
                 </div>
+                <div
+                  class="rt-th rt-resizable-header -cursor-pointer"
+                  role="columnheader"
+                  style="flex:100 0 auto;width:100px;max-width:100px"
+                  tabindex="-1"
+                >
+                  <div
+                    class="rt-resizable-header-content"
+                  >
+                    Total
+                  </div>
+                  <div
+                    class="rt-resizer"
+                  />
+                </div>
               </div>
             </div>
             <div
               class="rt-tbody"
-              style="min-width:400px"
+              style="min-width:500px"
             >
               <div
                 class="rt-tr-group"
@@ -552,6 +616,11 @@ exports[`renders recurring payment table with end 1`] = `
                   >
                     1
                   </div>
+                  <div
+                    class="rt-td"
+                    role="gridcell"
+                    style="flex:100 0 auto;width:100px;max-width:100px"
+                  />
                 </div>
               </div>
             </div>
@@ -601,7 +670,7 @@ exports[`renders recurring payment table with times 1`] = `
           >
             <div
               class="rt-thead -header"
-              style="min-width:400px"
+              style="min-width:500px"
             >
               <div
                 class="rt-tr"
@@ -667,11 +736,26 @@ exports[`renders recurring payment table with times 1`] = `
                     class="rt-resizer"
                   />
                 </div>
+                <div
+                  class="rt-th rt-resizable-header -cursor-pointer"
+                  role="columnheader"
+                  style="flex:100 0 auto;width:100px;max-width:100px"
+                  tabindex="-1"
+                >
+                  <div
+                    class="rt-resizable-header-content"
+                  >
+                    Total
+                  </div>
+                  <div
+                    class="rt-resizer"
+                  />
+                </div>
               </div>
             </div>
             <div
               class="rt-tbody"
-              style="min-width:400px"
+              style="min-width:500px"
             >
               <div
                 class="rt-tr-group"
@@ -709,6 +793,11 @@ exports[`renders recurring payment table with times 1`] = `
                   >
                     1
                   </div>
+                  <div
+                    class="rt-td"
+                    role="gridcell"
+                    style="flex:100 0 auto;width:100px;max-width:100px"
+                  />
                 </div>
               </div>
             </div>

--- a/scripts/src/__tests__/__snapshots__/Payment.unit.test.tsx.snap
+++ b/scripts/src/__tests__/__snapshots__/Payment.unit.test.tsx.snap
@@ -101,6 +101,228 @@ exports[`doesn't render payment table when paymentInfo.items is none 1`] = `
 </div>
 `;
 
+exports[`renders installment payment table 1`] = `
+<div>
+  <h1
+    class="text-center my-2"
+  >
+    Payment
+  </h1>
+  <div>
+    <div>
+      <div
+        class="mb-2"
+      >
+        <div
+          class="ReactTable my-4"
+        >
+          <div
+            class="rt-table"
+            role="grid"
+          >
+            <div
+              class="rt-thead -header"
+              style="min-width:500px"
+            >
+              <div
+                class="rt-tr"
+                role="row"
+              >
+                <div
+                  class="rt-th rt-resizable-header -cursor-pointer"
+                  role="columnheader"
+                  style="flex:100 0 auto;width:100px"
+                  tabindex="-1"
+                >
+                  <div
+                    class="rt-resizable-header-content"
+                  >
+                    Name
+                  </div>
+                  <div
+                    class="rt-resizer"
+                  />
+                </div>
+                <div
+                  class="rt-th rt-resizable-header -cursor-pointer"
+                  role="columnheader"
+                  style="flex:100 0 auto;width:100px"
+                  tabindex="-1"
+                >
+                  <div
+                    class="rt-resizable-header-content"
+                  >
+                    Description
+                  </div>
+                  <div
+                    class="rt-resizer"
+                  />
+                </div>
+                <div
+                  class="rt-th rt-resizable-header -cursor-pointer"
+                  role="columnheader"
+                  style="flex:100 0 auto;width:100px"
+                  tabindex="-1"
+                >
+                  <div
+                    class="rt-resizable-header-content"
+                  >
+                    Amount
+                  </div>
+                  <div
+                    class="rt-resizer"
+                  />
+                </div>
+                <div
+                  class="rt-th rt-resizable-header -cursor-pointer"
+                  role="columnheader"
+                  style="flex:100 0 auto;width:100px"
+                  tabindex="-1"
+                >
+                  <div
+                    class="rt-resizable-header-content"
+                  >
+                    Quantity
+                  </div>
+                  <div
+                    class="rt-resizer"
+                  />
+                </div>
+                <div
+                  class="rt-th rt-resizable-header -cursor-pointer"
+                  role="columnheader"
+                  style="flex:100 0 auto;width:100px;max-width:100px"
+                  tabindex="-1"
+                >
+                  <div
+                    class="rt-resizable-header-content"
+                  >
+                    Total
+                  </div>
+                  <div
+                    class="rt-resizer"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="rt-tbody"
+              style="min-width:500px"
+            >
+              <div
+                class="rt-tr-group"
+                role="rowgroup"
+              >
+                <div
+                  class="rt-tr -odd"
+                  role="row"
+                >
+                  <div
+                    class="rt-td"
+                    role="gridcell"
+                    style="flex:100 0 auto;width:100px"
+                  >
+                    One
+                  </div>
+                  <div
+                    class="rt-td"
+                    role="gridcell"
+                    style="flex:100 0 auto;width:100px"
+                  >
+                    One
+                  </div>
+                  <div
+                    class="rt-td"
+                    role="gridcell"
+                    style="text-align:right;flex:100 0 auto;width:100px"
+                  >
+                    $120.00
+                  </div>
+                  <div
+                    class="rt-td"
+                    role="gridcell"
+                    style="text-align:right;flex:100 0 auto;width:100px"
+                  >
+                    1
+                  </div>
+                  <div
+                    class="rt-td"
+                    role="gridcell"
+                    style="text-align:right;flex:100 0 auto;width:100px;max-width:100px"
+                  >
+                    $120.00
+                  </div>
+                </div>
+              </div>
+              <div
+                class="rt-tr-group"
+                role="rowgroup"
+              >
+                <div
+                  class="rt-tr -even"
+                  role="row"
+                >
+                  <div
+                    class="rt-td"
+                    role="gridcell"
+                    style="flex:100 0 auto;width:100px"
+                  >
+                    Installment
+                  </div>
+                  <div
+                    class="rt-td"
+                    role="gridcell"
+                    style="flex:100 0 auto;width:100px"
+                  >
+                    Installment
+                  </div>
+                  <div
+                    class="rt-td"
+                    role="gridcell"
+                    style="text-align:right;flex:100 0 auto;width:100px"
+                  >
+                    $12.00
+                  </div>
+                  <div
+                    class="rt-td"
+                    role="gridcell"
+                    style="text-align:right;flex:100 0 auto;width:100px"
+                  >
+                     every month for 10 times
+                  </div>
+                  <div
+                    class="rt-td"
+                    role="gridcell"
+                    style="text-align:right;flex:100 0 auto;width:100px;max-width:100px"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="-loading"
+          >
+            <div
+              class="-loading-inner"
+            >
+              Loading...
+            </div>
+          </div>
+        </div>
+        Total Amount: $120.00
+      </div>
+    </div>
+  </div>
+  <div>
+    <div
+      class="alert alert-info"
+    >
+      We have already received your payment. No additional payment necessary -- you will receive a confirmation email shortly about your update.
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders payment table on new response 1`] = `
 <div>
   <h1
@@ -176,7 +398,7 @@ exports[`renders payment table on new response 1`] = `
                 <div
                   class="rt-th rt-resizable-header -cursor-pointer"
                   role="columnheader"
-                  style="flex:100 0 auto;width:100px;max-width:100px"
+                  style="flex:100 0 auto;width:100px"
                   tabindex="-1"
                 >
                   <div
@@ -234,22 +456,24 @@ exports[`renders payment table on new response 1`] = `
                   <div
                     class="rt-td"
                     role="gridcell"
-                    style="flex:100 0 auto;width:100px"
+                    style="text-align:right;flex:100 0 auto;width:100px"
                   >
                     $12.00
                   </div>
                   <div
                     class="rt-td"
                     role="gridcell"
-                    style="flex:100 0 auto;width:100px;max-width:100px"
+                    style="text-align:right;flex:100 0 auto;width:100px"
                   >
                     1
                   </div>
                   <div
                     class="rt-td"
                     role="gridcell"
-                    style="flex:100 0 auto;width:100px;max-width:100px"
-                  />
+                    style="text-align:right;flex:100 0 auto;width:100px;max-width:100px"
+                  >
+                    $12.00
+                  </div>
                 </div>
               </div>
             </div>
@@ -353,7 +577,7 @@ exports[`renders payment table with amount received 1`] = `
                 <div
                   class="rt-th rt-resizable-header -cursor-pointer"
                   role="columnheader"
-                  style="flex:100 0 auto;width:100px;max-width:100px"
+                  style="flex:100 0 auto;width:100px"
                   tabindex="-1"
                 >
                   <div
@@ -411,22 +635,24 @@ exports[`renders payment table with amount received 1`] = `
                   <div
                     class="rt-td"
                     role="gridcell"
-                    style="flex:100 0 auto;width:100px"
+                    style="text-align:right;flex:100 0 auto;width:100px"
                   >
                     $12.00
                   </div>
                   <div
                     class="rt-td"
                     role="gridcell"
-                    style="flex:100 0 auto;width:100px;max-width:100px"
+                    style="text-align:right;flex:100 0 auto;width:100px"
                   >
                     1
                   </div>
                   <div
                     class="rt-td"
                     role="gridcell"
-                    style="flex:100 0 auto;width:100px;max-width:100px"
-                  />
+                    style="text-align:right;flex:100 0 auto;width:100px;max-width:100px"
+                  >
+                    $12.00
+                  </div>
                 </div>
               </div>
             </div>
@@ -547,7 +773,7 @@ exports[`renders recurring payment table with end 1`] = `
                 <div
                   class="rt-th rt-resizable-header -cursor-pointer"
                   role="columnheader"
-                  style="flex:100 0 auto;width:100px;max-width:100px"
+                  style="flex:100 0 auto;width:100px"
                   tabindex="-1"
                 >
                   <div
@@ -605,22 +831,24 @@ exports[`renders recurring payment table with end 1`] = `
                   <div
                     class="rt-td"
                     role="gridcell"
-                    style="flex:100 0 auto;width:100px"
+                    style="text-align:right;flex:100 0 auto;width:100px"
                   >
-                    $12.00 every month for 10 times
+                    $12.00
                   </div>
                   <div
                     class="rt-td"
                     role="gridcell"
-                    style="flex:100 0 auto;width:100px;max-width:100px"
+                    style="text-align:right;flex:100 0 auto;width:100px"
                   >
                     1
                   </div>
                   <div
                     class="rt-td"
                     role="gridcell"
-                    style="flex:100 0 auto;width:100px;max-width:100px"
-                  />
+                    style="text-align:right;flex:100 0 auto;width:100px;max-width:100px"
+                  >
+                    $120.00
+                  </div>
                 </div>
               </div>
             </div>
@@ -635,7 +863,7 @@ exports[`renders recurring payment table with end 1`] = `
             </div>
           </div>
         </div>
-        Total Amount: $12.00
+        Total Amount: $120.00
       </div>
     </div>
   </div>
@@ -724,7 +952,7 @@ exports[`renders recurring payment table with times 1`] = `
                 <div
                   class="rt-th rt-resizable-header -cursor-pointer"
                   role="columnheader"
-                  style="flex:100 0 auto;width:100px;max-width:100px"
+                  style="flex:100 0 auto;width:100px"
                   tabindex="-1"
                 >
                   <div
@@ -782,22 +1010,24 @@ exports[`renders recurring payment table with times 1`] = `
                   <div
                     class="rt-td"
                     role="gridcell"
-                    style="flex:100 0 auto;width:100px"
+                    style="text-align:right;flex:100 0 auto;width:100px"
                   >
-                    $12.00 every month
+                    $12.00
                   </div>
                   <div
                     class="rt-td"
                     role="gridcell"
-                    style="flex:100 0 auto;width:100px;max-width:100px"
+                    style="text-align:right;flex:100 0 auto;width:100px"
                   >
                     1
                   </div>
                   <div
                     class="rt-td"
                     role="gridcell"
-                    style="flex:100 0 auto;width:100px;max-width:100px"
-                  />
+                    style="text-align:right;flex:100 0 auto;width:100px;max-width:100px"
+                  >
+                    $12.00
+                  </div>
                 </div>
               </div>
             </div>

--- a/scripts/src/__tests__/__snapshots__/Payment.unit.test.tsx.snap
+++ b/scripts/src/__tests__/__snapshots__/Payment.unit.test.tsx.snap
@@ -1,5 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`calculatePaymentInfo() calculates installments from multiple totals 1`] = `
+Object {
+  "items": Array [
+    Object {
+      "amount": 2,
+      "quantity": 2,
+    },
+    Object {
+      "amount": -1,
+      "quantity": 1,
+    },
+    Object {
+      "amount": -1,
+      "quantity": 1,
+    },
+    Object {
+      "amount": 1,
+      "installment": true,
+      "quantity": 1,
+      "recurrenceDuration": "1M",
+      "recurrenceTimes": 2,
+    },
+  ],
+  "total": 2,
+}
+`;
+
+exports[`calculatePaymentInfo() calculates simple paymentInfo 1`] = `
+Object {
+  "items": Array [
+    Object {
+      "amount": 2,
+      "quantity": 2,
+    },
+  ],
+  "total": 4,
+}
+`;
+
+exports[`calculatePaymentInfo() calculates total items in paymentInfo last 1`] = `
+Object {
+  "items": Array [
+    Object {
+      "amount": 2,
+      "quantity": 2,
+    },
+    Object {
+      "amount": -0.4,
+      "quantity": 1,
+    },
+  ],
+  "total": 3.6,
+}
+`;
+
+exports[`calculatePaymentInfo() doesn't include installments in total calculation 1`] = `
+Object {
+  "items": Array [
+    Object {
+      "amount": 2,
+      "quantity": 2,
+    },
+    Object {
+      "amount": 2,
+      "installment": true,
+      "quantity": 1,
+      "recurrenceDuration": "1M",
+      "recurrenceTimes": 2,
+    },
+  ],
+  "total": 4,
+}
+`;
+
 exports[`doesn't render payment table when paymentInfo.items is none 1`] = `
 <div>
   <h1

--- a/scripts/src/form/confirmation/PaymentTable.tsx
+++ b/scripts/src/form/confirmation/PaymentTable.tsx
@@ -21,6 +21,9 @@ function formatRecurrence({ recurrenceDuration, recurrenceTimes }) {
   });
   return rrule.toText();
 }
+
+const numericColStyle = { textAlign: "right" };
+
 class PaymentTable extends React.Component<IPaymentTableProps, any> {
   constructor(props: any) {
     super(props);
@@ -52,6 +55,7 @@ class PaymentTable extends React.Component<IPaymentTableProps, any> {
       {
         Header: "Amount",
         id: "amount",
+        style: numericColStyle,
         accessor: d =>
           this.formatPayment(d.amount, this.props.paymentInfo.currency) +
           (formatRecurrence(d) ? " " + formatRecurrence(d) : "")
@@ -59,11 +63,13 @@ class PaymentTable extends React.Component<IPaymentTableProps, any> {
       {
         Header: "Quantity",
         accessor: "quantity",
-        maxWidth: 100
+        maxWidth: 100,
+        style: numericColStyle
       },
       {
         Header: "Total",
         id: "total",
+        style: numericColStyle,
         maxWidth: 100,
         accessor: d =>
           this.formatPayment(d.total, this.props.paymentInfo.currency)

--- a/scripts/src/form/confirmation/PaymentTable.tsx
+++ b/scripts/src/form/confirmation/PaymentTable.tsx
@@ -67,7 +67,7 @@ class PaymentTable extends React.Component<IPaymentTableProps, any> {
         id: "quantity",
         style: numericColStyle,
         accessor: d =>
-          d.installment
+          d.recurrenceDuration
             ? formatRecurrence(d)
               ? " " + formatRecurrence(d)
               : ""

--- a/scripts/src/form/confirmation/PaymentTable.tsx
+++ b/scripts/src/form/confirmation/PaymentTable.tsx
@@ -30,6 +30,9 @@ class PaymentTable extends React.Component<IPaymentTableProps, any> {
   }
 
   formatPayment(total, currency = "USD") {
+    if (!total) {
+      return "";
+    }
     if (Intl && Intl.NumberFormat) {
       return Intl.NumberFormat("en-US", {
         style: "currency",
@@ -57,14 +60,18 @@ class PaymentTable extends React.Component<IPaymentTableProps, any> {
         id: "amount",
         style: numericColStyle,
         accessor: d =>
-          this.formatPayment(d.amount, this.props.paymentInfo.currency) +
-          (formatRecurrence(d) ? " " + formatRecurrence(d) : "")
+          this.formatPayment(d.amount, this.props.paymentInfo.currency)
       },
       {
         Header: "Quantity",
-        accessor: "quantity",
-        maxWidth: 100,
-        style: numericColStyle
+        id: "quantity",
+        style: numericColStyle,
+        accessor: d =>
+          d.installment
+            ? formatRecurrence(d)
+              ? " " + formatRecurrence(d)
+              : ""
+            : d.quantity
       },
       {
         Header: "Total",
@@ -72,7 +79,9 @@ class PaymentTable extends React.Component<IPaymentTableProps, any> {
         style: numericColStyle,
         maxWidth: 100,
         accessor: d =>
-          this.formatPayment(d.total, this.props.paymentInfo.currency)
+          d.installment
+            ? ""
+            : this.formatPayment(d.total, this.props.paymentInfo.currency)
       }
     ];
     let tableData = this.props.paymentInfo.items;

--- a/scripts/src/form/confirmation/PaymentTable.tsx
+++ b/scripts/src/form/confirmation/PaymentTable.tsx
@@ -60,6 +60,11 @@ class PaymentTable extends React.Component<IPaymentTableProps, any> {
         Header: "Quantity",
         accessor: "quantity",
         maxWidth: 100
+      },
+      {
+        Header: "Total",
+        accessor: "total",
+        maxWidth: 100
       }
     ];
     let tableData = this.props.paymentInfo.items;

--- a/scripts/src/form/confirmation/PaymentTable.tsx
+++ b/scripts/src/form/confirmation/PaymentTable.tsx
@@ -63,8 +63,10 @@ class PaymentTable extends React.Component<IPaymentTableProps, any> {
       },
       {
         Header: "Total",
-        accessor: "total",
-        maxWidth: 100
+        id: "total",
+        maxWidth: 100,
+        accessor: d =>
+          this.formatPayment(d.total, this.props.paymentInfo.currency)
       }
     ];
     let tableData = this.props.paymentInfo.items;

--- a/scripts/src/form/interfaces.d.ts
+++ b/scripts/src/form/interfaces.d.ts
@@ -41,6 +41,7 @@ export interface IPaymentInfoItem {
   name?: string;
   description?: string;
   quantity?: any;
+  total?: any;
   recurrenceDuration?: string;
   recurrenceTimes?: string;
   installment?: boolean;

--- a/scripts/src/form/payment/PaymentCalcTable.tsx
+++ b/scripts/src/form/payment/PaymentCalcTable.tsx
@@ -32,8 +32,8 @@ export function calculatePaymentInfo(paymentCalcInfo, formData) {
       paymentInfoItem.quantity,
       formData
     );
-    paymentInfo["total"] +=
-      paymentInfoItem["amount"] * paymentInfoItem["quantity"];
+    paymentInfoItem.total = paymentInfoItem.amount * paymentInfoItem.quantity;
+    paymentInfo["total"] += paymentInfoItem.total;
   }
   // Now take care of items for coupon code, round off, etc. -- which need the total value to work.
   formData["total"] = paymentInfo["total"];
@@ -46,8 +46,8 @@ export function calculatePaymentInfo(paymentCalcInfo, formData) {
       paymentInfoItem.quantity,
       formData
     );
-    paymentInfo["total"] +=
-      paymentInfoItem["amount"] * paymentInfoItem["quantity"];
+    paymentInfoItem.total = paymentInfoItem.amount * paymentInfoItem.quantity;
+    paymentInfo["total"] += paymentInfoItem.total;
   }
   formData["total"] = paymentInfo["total"];
   for (let paymentInfoItem of paymentInfoItemsInstallment) {
@@ -59,6 +59,12 @@ export function calculatePaymentInfo(paymentCalcInfo, formData) {
       paymentInfoItem.quantity,
       formData
     );
+    if (paymentInfoItem.recurrenceTimes) {
+      paymentInfoItem.total =
+        paymentInfoItem.amount *
+        paymentInfoItem.quantity *
+        paymentInfoItem.recurrenceTimes;
+    }
     // Don't add installment payments to the total.
   }
   delete formData["total"];

--- a/scripts/src/form/payment/PaymentCalcTable.tsx
+++ b/scripts/src/form/payment/PaymentCalcTable.tsx
@@ -63,7 +63,7 @@ export function calculatePaymentInfo(paymentCalcInfo, formData) {
       paymentInfoItem.total =
         paymentInfoItem.amount *
         paymentInfoItem.quantity *
-        paymentInfoItem.recurrenceTimes;
+        parseInt(paymentInfoItem.recurrenceTimes);
     }
     // Don't add installment payments to the total.
   }


### PR DESCRIPTION
- Show "total" column in payment table that is equal to amount * quantity.
- Right-align amount, quantity, total
- For recurring payments, move the duration / # of times description from "amount" to "quantity" column
- Fix bug: show duration / # of times description for non-installment recurring payments (in addition to installment recurring payments)
- For installment payments, don't show a total column.

![image](https://user-images.githubusercontent.com/1689183/62144533-da66db80-b2a6-11e9-81e8-72f6a9e3c9ac.png)
